### PR TITLE
MySQL dockerのplatform指定を削除する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   mysql:
     container_name: starry-mysql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   mysql:
     container_name: starry-mysql
     image: mysql:8.0
-    platform: linux/x86_64
     environment:
       MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: starry


### PR DESCRIPTION
## 対応背景
#34

## やったこと
- MySQL Dockerのplatform指定を削除
- composeファイルを最新のプラクティスに応じてリファクタ

## 備考
- ローカル環境にMySQL 8.0 linux/amd64のdocker imageがすでに存在する場合、削除してからもう一度`make migrate`などのコマンドを実行するとarm版がダウンロードされるはず

`linux/amd64`のイメージがインストールされている場合はハイライトされている (Docker desktop->imagesで確認できる)

<img width="197" alt="image" src="https://github.com/ispec-inc/starry/assets/97785630/ef8fec88-d2dd-4f82-940d-46cb1418e1bc">


削除して再インストールするコマンド
```shell
docker image rm mysql:8.0
make migrate
```

close #34 