### PR TITLE
ADR のバッジを装飾化

### DIFF
--- a/packages/orion/plop-templates/adr.md.hbs
+++ b/packages/orion/plop-templates/adr.md.hbs
@@ -1,5 +1,7 @@
 # {{title}}
-```{{tag.name}}```<br>
+
+![{{tag.name}}](https://img.shields.io/badge/{{tag.name}}-blue)
+
 {{username}}・{{date}}
 
 ## 背景

--- a/plop-templates/adr.md.hbs
+++ b/plop-templates/adr.md.hbs
@@ -1,5 +1,7 @@
 # {{title}}
-```{{tag.name}}```<br>
+
+![{{tag.name}}](https://img.shields.io/badge/{{tag.name}}-blue)
+
 {{username}}・{{date}}
 
 ## 背景


### PR DESCRIPTION
## 背景

https://github.com/ispec-inc/waroku-hk-api/pull/40 で markdownlint を行っていた時、`<br>` の埋め込みに対して警告が多発した。
せっかくなので、ADRのタグを [shields.io](https://shields.io/) 化した。

## サンプル

![backend](https://img.shields.io/badge/backend-blue)

## see also

https://rarafy.com/blog/2022/03/03/github-badge/